### PR TITLE
fix: no more 'runtimes' and 'modules' in orchestrator response

### DIFF
--- a/libsilverline/orchestrator.py
+++ b/libsilverline/orchestrator.py
@@ -181,11 +181,11 @@ class OrchestratorMixin:
 
     def get_runtimes(self):
         """Get runtimes from REST API."""
-        return self._get_json("runtimes")
+        return self._get_json("runtimes")['results']
 
     def get_modules(self):
         """Get modules from REST API."""
-        return self._get_json("modules")
+        return self._get_json("modules")['results']
 
     def get_runtime(self, rt):
         """Get runtime full metadata from REST API."""

--- a/libsilverline/orchestrator.py
+++ b/libsilverline/orchestrator.py
@@ -181,11 +181,11 @@ class OrchestratorMixin:
 
     def get_runtimes(self):
         """Get runtimes from REST API."""
-        return self._get_json("runtimes")['runtimes']
+        return self._get_json("runtimes")
 
     def get_modules(self):
         """Get modules from REST API."""
-        return self._get_json("modules")['modules']
+        return self._get_json("modules")
 
     def get_runtime(self, rt):
         """Get runtime full metadata from REST API."""


### PR DESCRIPTION
Adjust to change in orchestrator API: https://github.com/SilverLineFramework/orchestrator/pull/97